### PR TITLE
Adding name mapping to enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,18 +86,20 @@ data class Person(
         override fun protoUnmarshal(u: pbandk.Unmarshaller) = Person.protoUnmarshalImpl(u)
     }
 
-    data class PhoneType(override val value: Int) : pbandk.Message.Enum {
-        companion object : pbandk.Message.Enum.Companion<PhoneType> {
-            val MOBILE = PhoneType(0)
-            val HOME = PhoneType(1)
-            val WORK = PhoneType(2)
+    sealed class PhoneType(override val value: Int, override val name: String? = null) : pbandk.Message.NamedEnum {
+        override fun equals(other: kotlin.Any?) = other is PhoneType && other.value == value
+        override fun hashCode() = value.hashCode()
+        override fun toString() = "PhoneType.${name ?: "UNRECOGNIZED"}(value=$value)"
 
-            override fun fromValue(value: Int) = when (value) {
-                0 -> MOBILE
-                1 -> HOME
-                2 -> WORK
-                else -> PhoneType(value)
-            }
+        object Mobile : PhoneType(0, "MOBILE")
+        object Home : PhoneType(1, "HOME")
+        object Work : PhoneType(2, "WORK")
+        class Unrecognized(value: Int) : PhoneType(value)
+
+        companion object : pbandk.Message.NamedEnum.Companion<PhoneType> {
+            override val values = listOf(Mobile, Home, Work)
+            override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: Unrecognized(value)
+            override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No PhoneType with name: $name")
         }
     }
 

--- a/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/CodeGenerator.kt
@@ -27,15 +27,19 @@ open class CodeGenerator(val file: File, val kotlinTypeMappings: Map<String, Str
     }
 
     protected fun writeEnumType(type: File.Type.Enum) {
-        // Enums are data classes w/ a single value and a companion object with known values
-        line().line("data class ${type.kotlinTypeName}(override val value: Int) : pbandk.Message.Enum {").indented {
-            line("companion object : pbandk.Message.Enum.Companion<${type.kotlinTypeName}> {").indented {
-                type.values.forEach { line("val ${it.kotlinValueName} = ${type.kotlinTypeName}(${it.number})") }
-                line()
-                line("override fun fromValue(value: Int) = when (value) {").indented {
-                    type.values.forEach { line("${it.number} -> ${it.kotlinValueName}") }
-                    line("else -> ${type.kotlinTypeName}(value)")
-                }.line("}")
+        // Enums are sealed classes w/ a value and a name, and a companion object with all values
+        line().line("sealed class ${type.kotlinTypeName}(override val value: Int, override val name: String? = null) : pbandk.Message.NamedEnum {").indented {
+            line("override fun equals(other: kotlin.Any?) = other is ${type.kotlinTypeName} && other.value == value")
+            line("override fun hashCode() = value.hashCode()")
+            line("override fun toString() = \"${type.kotlinTypeName}.\${name ?: \"UNRECOGNIZED\"}(value=\$value)\"")
+            line()
+            type.values.forEach { line("object ${it.kotlinValueTypeName} : ${type.kotlinTypeName}(${it.number}, \"${it.name}\")") }
+            line("class Unrecognized(value: Int) : ${type.kotlinTypeName}(value)")
+            line()
+            line("companion object : pbandk.Message.NamedEnum.Companion<${type.kotlinTypeName}> {").indented {
+                line("val values: List<${type.kotlinTypeName}> by lazy { listOf(${type.values.joinToString(", ") { it.kotlinValueTypeName }}) }")
+                line("override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: Unrecognized(value)")
+                line("override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException(\"No ${type.kotlinTypeName} with name: \$name\")")
             }.line("}")
         }.line("}")
     }

--- a/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/File.kt
+++ b/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/File.kt
@@ -43,7 +43,7 @@ data class File(
             val values: List<Value>,
             override val kotlinTypeName: String
         ) : Type() {
-            data class Value(val number: Int, val name: String, val kotlinValueName: String)
+            data class Value(val number: Int, val name: String, val kotlinValueTypeName: String)
         }
     }
 

--- a/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/FileBuilder.kt
+++ b/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/FileBuilder.kt
@@ -36,9 +36,10 @@ open class FileBuilder(val namer: Namer = Namer.Standard, val supportMaps: Boole
             values + File.Type.Enum.Value(
                 number = value.number!!,
                 name = value.name!!,
-                kotlinValueName = namer.newEnumValueName(
+                kotlinValueTypeName = namer.newEnumValueTypeName(
+                    enumDesc.name!!,
                     value.name!!,
-                    values.map { it.kotlinValueName })
+                    values.map { it.kotlinValueTypeName })
             )
         },
         kotlinTypeName = namer.newTypeName(enumDesc.name!!, usedTypeNames).also {

--- a/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/FileBuilder.kt
+++ b/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/FileBuilder.kt
@@ -20,6 +20,7 @@ open class FileBuilder(val namer: Namer = Namer.Standard, val supportMaps: Boole
             ?: ctx.fileDesc.options?.uninterpretedOption?.find {
                 it.name.singleOrNull()?.namePart == "kotlin_package"
             }?.stringValue?.array?.let(Util::utf8ToString)
+            ?: ctx.packageMappings[ctx.fileDesc.`package`]
             ?: ctx.fileDesc.options?.javaPackage?.takeIf { it.isNotEmpty() }
             ?: ctx.fileDesc.`package`?.takeIf { it.isNotEmpty() }
 
@@ -164,6 +165,13 @@ open class FileBuilder(val namer: Namer = Namer.Standard, val supportMaps: Boole
     }
 
     data class Context(val fileDesc: FileDescriptorProto, val params: Map<String, String>) {
+        // Support option kotlin_package_mapping=from.package1->to.package1;from.package2->to.package2
+        val packageMappings = params["kotlin_package_mapping"]
+            ?.split(";")
+            ?.map { it.substringBefore("->") to it.substringAfter("->", "") }
+            ?.toMap()
+            ?: emptyMap()
+
         fun findLocalMessage(name: String, parent: DescriptorProto? = null): DescriptorProto? {
             // Get the set to look in and the type name
             val (lookIn, typeName) =

--- a/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/Main.kt
+++ b/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/Main.kt
@@ -23,12 +23,13 @@ fun runGenerator(request: CodeGeneratorRequest): CodeGeneratorResponse {
     // Convert to file model and generate the code only for ones requested
     val kotlinTypeMappings = mutableMapOf<String, String>()
     return CodeGeneratorResponse(file = request.protoFile.flatMap { protoFile ->
-        debug { "Reading ${protoFile.name}" }
+        val packageName = protoFile.`package`
+        debug { "Reading ${protoFile.name}, package: $packageName" }
         val needToGenerate = request.fileToGenerate.contains(protoFile.name)
         // Convert the file to our model
         val file = FileBuilder.buildFile(FileBuilder.Context(protoFile, params.let {
             // As a special case, if we're not generating it but it's a well-known type package, change it our known one
-            if (needToGenerate || protoFile.`package` != "google.protobuf") it
+            if (needToGenerate || packageName != "google.protobuf") it
             else it + ("kotlin_package" to "pbandk.wkt")
         }))
         // Update the type mappings

--- a/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/Namer.kt
+++ b/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/Namer.kt
@@ -3,7 +3,7 @@ package pbandk.gen
 interface Namer {
     fun newTypeName(preferred: String, nameSet: Collection<String>): String
     fun newFieldName(preferred: String, nameSet: Collection<String>): String
-    fun newEnumValueName(preferred: String, nameSet: Collection<String>): String
+    fun newEnumValueTypeName(enumTypeName: String, preferred: String, nameSet: Collection<String>): String
 
     open class Standard : Namer {
         val disallowedTypeNames = setOf(
@@ -11,6 +11,9 @@ interface Namer {
         )
         val disallowedFieldNames = setOf(
             "emptyList", "pbandk", "plus", "protoMarshal", "protoSize", "protoUnmarshal", "unknownFields"
+        )
+        val disallowedValueTypeNames = setOf(
+            "Unrecognized"
         )
         val kotlinKeywords = setOf(
             "as", "break", "class", "continue", "do", "else", "false", "for", "fun", "if", "in",
@@ -27,6 +30,9 @@ interface Namer {
             }
         }
 
+        protected fun splitWordsToSnakeCase(str: String) =
+            str.replace(Regex("(?<=[a-z])([A-Z0-9])"), "_$1").toLowerCase()
+
         override fun newTypeName(preferred: String, nameSet: Collection<String>): String {
             var name = underscoreToCamelCase(preferred).capitalize()
             while (nameSet.contains(name) || disallowedTypeNames.contains(name)) name += '_'
@@ -40,9 +46,12 @@ interface Namer {
             return name
         }
 
-        override fun newEnumValueName(preferred: String, nameSet: Collection<String>): String {
-            var name = preferred.toUpperCase()
-            while (nameSet.contains(name)) name += '_'
+        override fun newEnumValueTypeName(enumTypeName: String, preferred: String, nameSet: Collection<String>): String {
+            val typePrefix = splitWordsToSnakeCase(enumTypeName) + '_'
+            var name = splitWordsToSnakeCase(preferred).substringAfter(typePrefix)
+            name = underscoreToCamelCase(name).capitalize()
+
+            while (nameSet.contains(name) || disallowedValueTypeNames.contains(name)) name += '_'
             return name
         }
 

--- a/runtime/runtime-common/src/main/kotlin/pbandk/Message.kt
+++ b/runtime/runtime-common/src/main/kotlin/pbandk/Message.kt
@@ -18,6 +18,14 @@ interface Message<T : Message<T>> {
             fun fromValue(value: Int): T
         }
     }
+
+    interface NamedEnum : Enum {
+        val name: String?
+
+        interface Companion<T : Enum> : Enum.Companion<T> {
+            fun fromName(name: String): T
+        }
+    }
 }
 
 operator fun <T : Message<T>> Message<T>?.plus(other: T?) = this?.plus(other) ?: other


### PR DESCRIPTION
@garyp This let's us use, e.g., `RoomInvitation.fromName("PENDING")`.  I created a separate `NamedEnum` instead of just using `Enum`, since there are a dozen or so existing enums that extend `Enum` that I didn't think needed the name mapping, but I could be persuaded if you think consistency for all `Enum`s is better.