### PR TITLE
Kotlin package mapping

### DIFF
--- a/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/FileBuilder.kt
+++ b/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/FileBuilder.kt
@@ -20,6 +20,7 @@ open class FileBuilder(val namer: Namer = Namer.Standard, val supportMaps: Boole
             ?: ctx.fileDesc.options?.uninterpretedOption?.find {
                 it.name.singleOrNull()?.namePart == "kotlin_package"
             }?.stringValue?.array?.let(Util::utf8ToString)
+            ?: ctx.packageMappings[ctx.fileDesc.`package`]
             ?: ctx.fileDesc.options?.javaPackage?.takeIf { it.isNotEmpty() }
             ?: ctx.fileDesc.`package`?.takeIf { it.isNotEmpty() }
 
@@ -164,6 +165,13 @@ open class FileBuilder(val namer: Namer = Namer.Standard, val supportMaps: Boole
     }
 
     data class Context(val fileDesc: FileDescriptorProto, val params: Map<String, String>) {
+        // Support option kotlin_package_mapping=from.package1->to.package1;from.package2->to.package2
+        val packageMappings = params["kotlin_package_mapping"]
+            ?.split(";")
+            ?.map { it.substringBefore("->") to it.substringAfter("->", "") }
+            ?.toMap()
+            ?: emptyMap()
+
         fun findLocalMessage(name: String, parent: DescriptorProto? = null): DescriptorProto? {
             // Get the set to look in and the type name
             val (lookIn, typeName) =

--- a/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/Main.kt
+++ b/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/Main.kt
@@ -23,12 +23,13 @@ fun runGenerator(request: CodeGeneratorRequest): CodeGeneratorResponse {
     // Convert to file model and generate the code only for ones requested
     val kotlinTypeMappings = mutableMapOf<String, String>()
     return CodeGeneratorResponse(file = request.protoFile.flatMap { protoFile ->
-        debug { "Reading ${protoFile.name}" }
+        val packageName = protoFile.`package`
+        debug { "Reading ${protoFile.name}, package: $packageName" }
         val needToGenerate = request.fileToGenerate.contains(protoFile.name)
         // Convert the file to our model
         val file = FileBuilder.buildFile(FileBuilder.Context(protoFile, params.let {
             // As a special case, if we're not generating it but it's a well-known type package, change it our known one
-            if (needToGenerate || protoFile.`package` != "google.protobuf") it
+            if (needToGenerate || packageName != "google.protobuf") it
             else it + ("kotlin_package" to "pbandk.wkt")
         }))
         // Update the type mappings


### PR DESCRIPTION
@garyp This PR let's us do the following:
```
    option 'kotlin_package_mapping=google.api->pbandk.google.api'
```

I'm using a semi-colon delimiter, and arrow mapping, since colons were being parsed out from somewhere, and commas are used for separating params... open to feedback of course.